### PR TITLE
Use testing.TB where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ in your tests. Here is an example:
 ```go
 // NewDB is a helper that returns an open connection to a unique and isolated
 // test database, fully migrated and ready for you to query.
-func NewDB(t *testing.T) *sql.DB {
-  t.Helper()
+func NewDB(tb testing.TB) *sql.DB {
+  tb.Helper()
   conf := pgtestdb.Config{
     DriverName: "pgx",
     User:       "postgres",
@@ -119,7 +119,7 @@ func NewDB(t *testing.T) *sql.DB {
   // You'll want to use a real migrator, this is just an example. See the rest
   // of the docs for more information.
   var migrator pgtestdb.Migrator = pgtestdb.NoopMigrator{}
-  return pgtestdb.New(t, conf, migrator)
+  return pgtestdb.New(tb, conf, migrator)
 }
 ```
 
@@ -144,8 +144,8 @@ If you wish to use something that is not `sql.DB`, you can use the
 ```go
 // NewPgx is a helper that returns an open pgx connection to a unique and
 // isolated test database, fully migrated and ready for you to query.
-func NewPgx(t *testing.T, ctx context.Context) *pgx.Conn {
-  t.Helper()
+func NewPgx(tb testing.TB, ctx context.Context) *pgx.Conn {
+  tb.Helper()
   conf := pgtestdb.Config{
     DriverName: "pgx",
     User:       "postgres",
@@ -157,12 +157,12 @@ func NewPgx(t *testing.T, ctx context.Context) *pgx.Conn {
   // You'll want to use a real migrator, this is just an example. See the rest
   // of the docs for more information.
   var migrator pgtestdb.Migrator = pgtestdb.NoopMigrator{}
-  instance := pgtestdb.NewInstance(t, conf, migrator)
+  instance := pgtestdb.NewInstance(tb, conf, migrator)
   conn, err := pgx.Connect(ctx, instance.URL())
   if err != nil {
-    t.Fatal(err)
+    tb.Fatal(err)
   }
-  t.Cleanup(func() {
+  tb.Cleanup(func() {
     conn.Close(ctx)
   })
   return conn

--- a/readme_test.go
+++ b/readme_test.go
@@ -42,8 +42,8 @@ func TestMyExample(t *testing.T) {
 
 // NewDB is a helper that returns an open connection to a unique and isolated
 // test database, fully migrated and ready for you to query.
-func NewDB(t *testing.T) *sql.DB {
-	t.Helper()
+func NewDB(tb testing.TB) *sql.DB {
+	tb.Helper()
 	conf := pgtestdb.Config{
 		DriverName: "pgx",
 		User:       "postgres",
@@ -55,7 +55,7 @@ func NewDB(t *testing.T) *sql.DB {
 	// You'll want to use a real migrator, this is just an example. See the rest
 	// of the docs for more information.
 	var migrator pgtestdb.Migrator = pgtestdb.NoopMigrator{}
-	return pgtestdb.New(t, conf, migrator)
+	return pgtestdb.New(tb, conf, migrator)
 }
 
 func TestAQuery(t *testing.T) {
@@ -70,8 +70,8 @@ func TestAQuery(t *testing.T) {
 
 // NewPgx is a helper that returns an open pgx connection to a unique and
 // isolated test database, fully migrated and ready for you to query.
-func NewPgx(t *testing.T, ctx context.Context) *pgx.Conn {
-	t.Helper()
+func NewPgx(tb testing.TB, ctx context.Context) *pgx.Conn {
+	tb.Helper()
 	conf := pgtestdb.Config{
 		DriverName: "pgx",
 		User:       "postgres",
@@ -83,12 +83,12 @@ func NewPgx(t *testing.T, ctx context.Context) *pgx.Conn {
 	// You'll want to use a real migrator, this is just an example. See the rest
 	// of the docs for more information.
 	var migrator pgtestdb.Migrator = pgtestdb.NoopMigrator{}
-	instance := pgtestdb.NewInstance(t, conf, migrator)
+	instance := pgtestdb.NewInstance(tb, conf, migrator)
 	conn, err := pgx.Connect(ctx, instance.URL())
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		conn.Close(ctx)
 	})
 	return conn

--- a/testdb_test.go
+++ b/testdb_test.go
@@ -35,8 +35,8 @@ func New(t *testing.T) *sql.DB {
 }
 
 // newPgx integrates pgtestdb with pgx.
-func newPgx(t *testing.T, ctx context.Context) *pgx.Conn {
-	t.Helper()
+func newPgx(tb testing.TB, ctx context.Context) *pgx.Conn {
+	tb.Helper()
 	dbconf := pgtestdb.Config{
 		DriverName: "pgx",
 		User:       "postgres",
@@ -46,14 +46,14 @@ func newPgx(t *testing.T, ctx context.Context) *pgx.Conn {
 		Options:    "sslmode=disable",
 	}
 	m := defaultMigrator()
-	instance := pgtestdb.NewInstance(t, dbconf, m)
+	instance := pgtestdb.NewInstance(tb, dbconf, m)
 	conn, err := pgx.Connect(ctx, instance.URL())
 	if err != nil {
-		t.Fatalf("could not connect to database: %s", err)
+		tb.Fatalf("could not connect to database: %s", err)
 	}
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		if err := conn.Close(ctx); err != nil {
-			t.Fatalf(
+			tb.Fatalf(
 				"cloud not close test pgx connection: '%s': %s",
 				instance.Database, err,
 			)


### PR DESCRIPTION
This change makes use of `testing.TB` to allow the `New` method be used in micro benchmarks too.

PS. This PR is dependent on #2 . If that change looks fine, please go ahead and merge that one first. If not, I'll update this one to reflect discussion there. :)