### PR TITLE
maint: clean up bunmigrator and related docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ for the most popular golang frameworks:
 - [dbmatemigrator](migrators/dbmatemigrator/) for [amacneil/dbmate](https://github.com/amacneil/dbmate)
 - [atlasmigrator](migrators/atlasmigrator/) for [ariga/atlas](https://github.com/ariga/atlas)
 - [sqlmigrator](migrators/sqlmigrator/) for [rubenv/sql-migrate](https://github.com/rubenv/sql-migrate)
+- [bunmigrator](migrators/bunmigrator/) for [uptrace/bun](https://github.com/uptrace/bun) (contributed by [@BrynBerkeley](https://github.com/BrynBerkeley))
 
 pgtestdb is concurrency-safe and I encourage you to run your tests in parallel.
 

--- a/migrators/bunmigrator/README.md
+++ b/migrators/bunmigrator/README.md
@@ -6,12 +6,20 @@ go get github.com/peterldowns/pgtestdb/migrators/bunmigrator@latest
 
 bunmigrator provides a migrator that can be used with projects that make use of [uptrace/bun](https://github.com/uptrace/bun) for migrations.
 
-Because `Hash()` requires calculating a unique hash based on the contents of migrations, this implementation only supports reading migration files from disk or an embedded filesystem.
+Because `Hash()` requires calculating a unique hash based on the contents of migrations, this implementation only supports reading migration files from disk or an embedded filesystem. This migrator does not support [go-based migrations](https://bun.uptrace.dev/guide/migrations.html#go-based-migrations).
 
 You can configure the migrations directory and the filesystem being used.
 Here's an example:
 
 ```go
+
+import (
+	// Initialize the "pgdriver" sql.DB driver
+	// Use this by setting `config.DriverName` to "pg".
+	// For more information, see https://bun.uptrace.dev/postgres/#pgdriver
+	_ "github.com/uptrace/bun/driver/pgdriver"
+)
+
 //go:embed migrations/*.sql
 var exampleFS embed.FS
 
@@ -20,6 +28,7 @@ func TestMigrateFromEmbeddedFS(t *testing.T) {
 	ctx := context.Background()
 	bm := bunmigrator.New("migrations", bunmigrator.WithFS(exampleFS))
 	db := pgtestdb.New(t, pgtestdb.Config{
+		// Use bun's "pgdriver" to connect.
 		DriverName: "pg",
 		Host:       "localhost",
 		User:       "postgres",
@@ -36,6 +45,7 @@ func TestMigrateFromDisk(t *testing.T) {
 	ctx := context.Background()
 	bm := bunmigrator.New("migrations")
 	db := pgtestdb.New(t, pgtestdb.Config{
+        // Use bun's "pgdriver" to connect.
 		DriverName: "pg",
 		Host:       "localhost",
 		User:       "postgres",


### PR DESCRIPTION
Followup to #8, which introduced the new `bunmigrator` package.

- Updates the `bunmigrator` documentation to show how to include the postgres driver being used in the tests.
- Moves table-initialization logic out of `bunmigrator.Prepare` and into `bunmigrator.Migrate`. This functions the same way, and will make my life slightly easier as I think about removing or replacing the `Prepare` method. (I'm thinking of removing it since it's unnecessary and unused by any of the migrators.)
- Updates the main README to mention that `bunmigrator` exists, and thank @BrynBerkeley for contributing it.