### PR TITLE
feat: parse Config from URL

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,70 @@
+package pgtestdb
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ConfigFromURL is a helper function to create a Config from a connection string
+// like "postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full".
+func ConfigFromURL(driverName, connString string, ops ...Option) (Config, error) {
+	cfg, err := parseURL(connString)
+	if err != nil {
+		return Config{}, err
+	}
+
+	cfg.DriverName = driverName
+
+	for _, op := range ops {
+		op(&cfg)
+	}
+
+	return cfg, nil
+}
+
+func parseURL(connString string) (Config, error) {
+	u, err := url.Parse(connString)
+	if err != nil {
+		return Config{}, err
+	}
+
+	if u.Scheme != "postgres" && u.Scheme != "postgresql" {
+		return Config{}, fmt.Errorf("invalid connection protocol: %s", u.Scheme)
+	}
+
+	cfg := Config{
+		Host:    u.Hostname(),
+		Port:    u.Port(),
+		Options: u.RawQuery,
+	}
+
+	if len(u.Path) > 1 {
+		cfg.Database = u.Path[1:]
+	}
+
+	if u.User != nil {
+		cfg.User = u.User.Username()
+		cfg.Password, _ = u.User.Password()
+	}
+
+	return cfg, nil
+}
+
+// Option provides a way to configure the [Config] used by [ConfigFromURL].
+type Option func(*Config)
+
+// WithTestRole sets the role used to create and connect to the template database
+// and each test database. See more [Config.TestRole].
+func WithTestRole(role Role) Option {
+	return func(cfg *Config) {
+		cfg.TestRole = &role
+	}
+}
+
+// WithForceTerminateConnections will force-disconnect any remaining
+// database connections prior to dropping the test database. See more [Config.ForceTerminateConnections].
+func WithForceTerminateConnections() Option {
+	return func(cfg *Config) {
+		cfg.ForceTerminateConnections = true
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,99 @@
+package pgtestdb_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/peterldowns/pgtestdb"
+)
+
+func TestConfigFromURL(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		url := "postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full"
+		want := pgtestdb.Config{
+			DriverName: "pgx",
+			Host:       "1.2.3.4",
+			Port:       "5432",
+			User:       "bob",
+			Password:   "secret",
+			Database:   "mydb",
+			Options:    "sslmode=verify-full",
+		}
+
+		cfg, err := pgtestdb.ConfigFromURL("pgx", url)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if diff := cmp.Diff(want, cfg); diff != "" {
+			t.Errorf("config mismatch (-want +got):\n%s", diff)
+		}
+
+		if cfg.URL() != url {
+			t.Fatalf("unexpected URL, want %s, got %s", url, cfg.URL())
+		}
+	})
+
+	t.Run("with options", func(t *testing.T) {
+		url := "postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full"
+		testRole := pgtestdb.Role{
+			Username:     "test",
+			Password:     "test",
+			Capabilities: "test",
+		}
+		want := pgtestdb.Config{
+			DriverName:                "pgx",
+			Host:                      "1.2.3.4",
+			Port:                      "5432",
+			User:                      "bob",
+			Password:                  "secret",
+			Database:                  "mydb",
+			Options:                   "sslmode=verify-full",
+			TestRole:                  &testRole,
+			ForceTerminateConnections: true,
+		}
+
+		cfg, err := pgtestdb.ConfigFromURL("pgx", url, pgtestdb.WithForceTerminateConnections(), pgtestdb.WithTestRole(testRole))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if diff := cmp.Diff(want, cfg); diff != "" {
+			t.Errorf("config mismatch (-want +got):\n%s", diff)
+		}
+
+		if cfg.URL() != url {
+			t.Fatalf("unexpected URL, want %s, got %s", url, cfg.URL())
+		}
+	})
+
+	t.Run("minimal", func(t *testing.T) {
+		url := "postgres://localhost:5432"
+		want := pgtestdb.Config{
+			DriverName: "pgx",
+			Host:       "localhost",
+			Port:       "5432",
+		}
+		cfg, err := pgtestdb.ConfigFromURL("pgx", url)
+		if err != nil {
+			t.Fatalf("expected error: %s", err)
+		}
+
+		if diff := cmp.Diff(want, cfg); diff != "" {
+			t.Errorf("config mismatch (-want +got):\n%s", diff)
+		}
+
+		if cfg.URL() != url {
+			t.Fatalf("unexpected URL, want %s, got %s", url, cfg.URL())
+		}
+	})
+
+	t.Run("bad protocol", func(t *testing.T) {
+		url := "http://example.com"
+		_, err := pgtestdb.ConfigFromURL("pgx", url)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	})
+}


### PR DESCRIPTION
This CR adds helper function to parse `Config` from connection string like "postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full".

Most of the time I'm passing around connection string as environment variable, which then requires to parse it to be able to create `Config`.

Hope this helper function will be enough 🙂.
I was thinking about using [ParseConfig](https://github.com/jackc/pgx/blob/c2175fe46e3d6f43af14a21b47386739d15e4ee0/pgconn/config.go#L235) from pgx, but then we will be in the territory when library will need to handle env variables and a lot different things.