### PR TITLE
fix(migrators/goose): read from filesytem if no FS

### DIFF
--- a/migrators/goosemigrator/goose.go
+++ b/migrators/goosemigrator/goose.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"io/fs"
-	"os"
 
 	"github.com/pressly/goose/v3"
 	"github.com/pressly/goose/v3/database"
@@ -44,7 +43,7 @@ func WithTableName(tableName string) Option {
 
 // WithFS specifies a `fs.FS` from which to read the migration files.
 //
-// Default: `os.DirFS(".")` (reads from the real filesystem in the current working directory)
+// Default: `<nil>` (reads from the real filesystem)
 //
 // https://github.com/pressly/goose#embedded-sql-migrations
 func WithFS(dir fs.FS) Option {
@@ -68,7 +67,7 @@ func New(migrationsDir string, opts ...Option) *GooseMigrator {
 	gm := &GooseMigrator{
 		MigrationsDir: migrationsDir,
 		TableName:     DefaultTableName,
-		FS:            os.DirFS("."),
+		FS:            nil,
 	}
 	for _, opt := range opts {
 		opt(gm)

--- a/migrators/goosemigrator/goose_test.go
+++ b/migrators/goosemigrator/goose_test.go
@@ -3,6 +3,7 @@ package goosemigrator_test
 import (
 	"context"
 	"embed"
+	"os"
 	"testing"
 
 	_ "github.com/jackc/pgx/v5/stdlib" // "pgx" driver
@@ -15,40 +16,59 @@ import (
 
 func TestGooseMigratorFromDisk(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	m := goosemigrator.New("migrations")
-	db := pgtestdb.New(t, pgtestdb.Config{
-		DriverName: "pgx",
-		Host:       "localhost",
-		User:       "postgres",
-		Password:   "password",
-		Port:       "5433",
-		Options:    "sslmode=disable",
-	}, m)
-	assert.NotEqual(t, nil, db)
+	runTest := func(t *testing.T, migrationsDir string) {
+		ctx := context.Background()
+		m := goosemigrator.New(migrationsDir)
+		db := pgtestdb.New(t, pgtestdb.Config{
+			DriverName: "pgx",
+			Host:       "localhost",
+			User:       "postgres",
+			Password:   "password",
+			Port:       "5433",
+			Options:    "sslmode=disable",
+		}, m)
+		assert.NotEqual(t, nil, db)
 
-	assert.NoFailures(t, func() {
-		var lastAppliedMigration int
-		err := db.QueryRowContext(ctx, "select max(version_id) from goose_db_version").Scan(&lastAppliedMigration)
+		assert.NoFailures(t, func() {
+			var lastAppliedMigration int
+			err := db.QueryRowContext(ctx, "select max(version_id) from goose_db_version").Scan(&lastAppliedMigration)
+			assert.Nil(t, err)
+			check.Equal(t, 2, lastAppliedMigration)
+		})
+
+		var numUsers int
+		err := db.QueryRowContext(ctx, "select count(*) from users").Scan(&numUsers)
 		assert.Nil(t, err)
-		check.Equal(t, 2, lastAppliedMigration)
+		check.Equal(t, 0, numUsers)
+
+		var numCats int
+		err = db.QueryRowContext(ctx, "select count(*) from cats").Scan(&numCats)
+		assert.Nil(t, err)
+		check.Equal(t, 0, numCats)
+
+		var numBlogPosts int
+		err = db.QueryRowContext(ctx, "select count(*) from blog_posts").Scan(&numBlogPosts)
+		assert.Nil(t, err)
+		check.Equal(t, 0, numBlogPosts)
+	}
+
+	t.Run("from current dir", func(t *testing.T) {
+		runTest(t, "migrations")
 	})
 
-	var numUsers int
-	err := db.QueryRowContext(ctx, "select count(*) from users").Scan(&numUsers)
-	assert.Nil(t, err)
-	check.Equal(t, 0, numUsers)
+	t.Run("from child dir", func(t *testing.T) {
+		if err := os.Chdir("migrations"); err != nil {
+			t.Fatalf("change directory: %s", err)
+		}
+		t.Cleanup(func() {
+			if err := os.Chdir(".."); err != nil {
+				t.Fatalf("change directory: %s", err)
+			}
+		})
 
-	var numCats int
-	err = db.QueryRowContext(ctx, "select count(*) from cats").Scan(&numCats)
-	assert.Nil(t, err)
-	check.Equal(t, 0, numCats)
-
-	var numBlogPosts int
-	err = db.QueryRowContext(ctx, "select count(*) from blog_posts").Scan(&numBlogPosts)
-	assert.Nil(t, err)
-	check.Equal(t, 0, numBlogPosts)
+		runTest(t, "../migrations")
+	})
 }
 
 //go:embed migrations/*.sql


### PR DESCRIPTION
This CR should allow to read migrations folder from parent directory like `../migrations`.

I have a `migrations` directory in the root of the project, so to make migrations work, I need to provide `FS` with root directory:

```go
root, err := filepath.Abs("../../../..")
if err != nil {
  t.Fatal("get abs path", err)
}

migrator := goosemigrator.New("migrations", goosemigrator.WithFS(os.DirFS(root)))
```

This CR should allow to do just:
```go
migrator := goosemigrator.New("../../../../migrations")
```

Also, `golangmigrator` does not have `fs.FS` by default too.