### PR TITLE
fix typo in TestDifferentHashesAlwaysResultInDifferentDatabases

### DIFF
--- a/testdb_test.go
+++ b/testdb_test.go
@@ -171,7 +171,7 @@ func TestDifferentHashesAlwaysResultInDifferentDatabases(t *testing.T) {
 	var countYYY int
 	err = yyydb.QueryRowContext(ctx, "select count(*) from yyy").Scan(&countYYY)
 	if check.Nil(t, err) {
-		check.Equal(t, 0, countXXX)
+		check.Equal(t, 0, countYYY)
 	}
 }
 


### PR DESCRIPTION
Fixes copy pasta in `TestDifferentHashesAlwaysResultInDifferentDatabases`. Doesn't affect the correctness of the test since both counts should be 0 when the queries succeed.