### PR TITLE
Feature: Add config option for cleaning up databases on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,11 @@ type Config struct {
     // pgtestdb will be unable to drop the database, and the test will be failed
     // with a warning.
     ForceTerminateConnections bool
+    // If true, the test database will be dropped even if the test fails.
+    // This prevents the test databases from accumulating in the database.
+    // This is useful for long-running tests, but may cause issues if you are
+    // debugging a test and want to inspect the database after it fails.
+    CleanupDatabaseOnFailure bool
 }
 
 // URL returns a postgres connection string in the format

--- a/testdb.go
+++ b/testdb.go
@@ -62,6 +62,11 @@ type Config struct {
 	// pgtestdb will be unable to drop the database, and the test will be failed
 	// with a warning.
 	ForceTerminateConnections bool
+	// If true, the test database will be dropped even if the test fails.
+	// This prevents the test databases from accumulating in the database.
+	// This is useful for long-running tests, but may cause issues if you are
+	// debugging a test and want to inspect the database after it fails.
+	CleanupDatabaseOnFailure bool
 }
 
 // Role contains the details of a postgres role (user) that will be used
@@ -221,8 +226,9 @@ func create(t TB, conf Config, migrator Migrator) (*Config, *sql.DB) {
 			return // unreachable
 		}
 
-		// If the test failed, leave the instance around for further investigation
-		if t.Failed() {
+		// If the test failed, leave the instance around for further investigation unless the CleanupDatabaseOnFailure
+		// flag is set to true.
+		if t.Failed() && !conf.CleanupDatabaseOnFailure {
 			return
 		}
 


### PR DESCRIPTION
This pull request introduces a new configuration option to manage the cleanup of test databases in the `pgtestdb` package. The most important changes include adding the `CleanupDatabaseOnFailure` flag to the `Config` struct and updating the database cleanup logic based on this flag.

Configuration Changes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R380-R384): Added a new `CleanupDatabaseOnFailure` flag to the `Config` struct to control whether the test database should be dropped even if the test fails.
* [`testdb.go`](diffhunk://#diff-61adefd750470b10caac043c47212559bc5ed8528a06bfa2db2bef24da6f78eaR65-R69): Added the `CleanupDatabaseOnFailure` flag to the `Config` struct to prevent the accumulation of test databases during long-running tests.

Database Cleanup Logic:

* [`testdb.go`](diffhunk://#diff-61adefd750470b10caac043c47212559bc5ed8528a06bfa2db2bef24da6f78eaL224-R231): Updated the `create` function to check the `CleanupDatabaseOnFailure` flag and drop the test database if the test fails and the flag is set to true.