### PR TITLE
fix(goosemigrator): allow using ../ relative paths to migrations

### DIFF
--- a/migrators/goosemigrator/goose.go
+++ b/migrators/goosemigrator/goose.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"io/fs"
-	"os"
 
 	"github.com/pressly/goose/v3"
 	"github.com/pressly/goose/v3/database"
@@ -68,7 +67,7 @@ func New(migrationsDir string, opts ...Option) *GooseMigrator {
 	gm := &GooseMigrator{
 		MigrationsDir: migrationsDir,
 		TableName:     DefaultTableName,
-		FS:            os.DirFS("."),
+		FS:            nil,
 	}
 	for _, opt := range opts {
 		opt(gm)


### PR DESCRIPTION
As initially requested by @dmksnnk (see https://github.com/peterldowns/pgtestdb/pull/26), this PR updates the goosemigrator to allow opening directories using relative paths. All the `fs` functions allow this if you just use a `nil` FS, but the goosemigrator was defaulting to using `os.DirFS(".")`, which prevents opening parent/relative paths.

## Tests
Adds a new testcase using a relative path. I can confirm that this test used to fail.